### PR TITLE
chore: align docs structure and cleanup

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -27,6 +27,7 @@ use BaconQrCode\Renderer\RendererStyle\GradientType;
 use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Writer;
 use BadMethodCallException;
+use Illuminate\Support\HtmlString;
 use InvalidArgumentException;
 use LaraZeus\QrCode\DataTypes\DataTypeInterface;
 
@@ -140,8 +141,8 @@ class Generator
             return;
         }
 
-        if (class_exists(\Illuminate\Support\HtmlString::class)) {
-            return new \Illuminate\Support\HtmlString($qrCode);
+        if (class_exists(HtmlString::class)) {
+            return new HtmlString($qrCode);
         }
 
         return $qrCode;

--- a/tests/DataTypes/WiFiTest.php
+++ b/tests/DataTypes/WiFiTest.php
@@ -3,7 +3,7 @@
 use LaraZeus\QrCode\DataTypes\WiFi;
 
 beforeEach(function () {
-    $this->wifi = new Wifi;
+    $this->wifi = new WiFi;
 });
 test('it generates a proper format with just the ssid', function () {
     $this->wifi->create([

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -10,6 +10,7 @@ use BaconQrCode\Renderer\Module\RoundnessModule;
 use BaconQrCode\Renderer\Module\SquareModule;
 use BaconQrCode\Renderer\RendererStyle\Gradient;
 use BaconQrCode\Renderer\RendererStyle\RendererStyle;
+use Illuminate\Support\HtmlString;
 use LaraZeus\QrCode\Generator;
 
 test('chaining is possible', function () {
@@ -158,6 +159,6 @@ test('it throws an exception if datatype is not found', function () {
     (new Generator)->notReal('fooBar');
 });
 test('generator can return illuminate support htmlstring', function () {
-    $this->getMockBuilder(\Illuminate\Support\HtmlString::class)->getMock();
-    expect((new Generator)->generate('fooBar'))->toBeInstanceOf(\Illuminate\Support\HtmlString::class);
+    $this->getMockBuilder(HtmlString::class)->getMock();
+    expect((new Generator)->generate('fooBar'))->toBeInstanceOf(HtmlString::class);
 });


### PR DESCRIPTION
## Summary
- Align plugin docs structure and cleanup
- Remove obsolete docs entries and legacy frontmatter keys
- Add/update Tailwind CSS v4 assets guidance where applicable

## Test plan
- [ ] Review docs pages render correctly
- [ ] Validate docs navigation and ordering
- [ ] Check package-specific installation and assets instructions
